### PR TITLE
Fix issue for Samsung Android Stock Browser

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -7,7 +7,7 @@ function getLocale(locale) {
     return global.Intl.DateTimeFormat().resolvedOptions && global.Intl.DateTimeFormat().resolvedOptions().locale
   }
 
-  if (global.chrome && typeof global.chrome.app.getDetails === 'function') {
+  if (global.chrome && global.chrome.app && typeof global.chrome.app.getDetails === 'function') {
     return global.chrome.app.getDetails().current_locale
   }
 


### PR DESCRIPTION
Some Android Samsung Stock Browsers have window.chrome defined but no "app" property underneath.