### PR TITLE
Fix the priority and deprecate `global.chrome.app.getDetails()`

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,15 +45,15 @@
   },
   "homepage": "https://github.com/moimikey/locale2",
   "devDependencies": {
-    "browserstack-runner": "^0.5.1",
+    "browserstack-runner": "^0.7.0",
     "browserstack-tape-reporter": "1.1.0",
-    "enhanced-resolve": "^3.3.0",
+    "enhanced-resolve": "^4.0.0-beta.4",
     "faucet": "0.0.1",
-    "rewire": "2.5.2",
+    "rewire": "3.0.2",
     "rewire-webpack": "1.0.1",
-    "tape": "^4.7.0",
+    "tape": "^4.8.0",
     "tape-catch": "1.0.6",
-    "webpack": "^3.3.0",
-    "webpack-dev-server": "^2.5.1"
+    "webpack": "^3.11.0",
+    "webpack-dev-server": "^2.11.1"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -8,7 +8,11 @@ function getLocale(locale) {
   }
 
   if (global.chrome && global.chrome.app && typeof global.chrome.app.getDetails === 'function') {
-    return global.chrome.app.getDetails().current_locale
+    locale = global.chrome.app.getDetails()
+
+    if (locale) {
+      return locale.current_locale
+    }
   }
 
   locale = (global.clientInformation || global.navigator || Object.create(null)).language ||

--- a/src/index.js
+++ b/src/index.js
@@ -11,11 +11,21 @@ function getLocale(locale) {
     }
   }
 
-  locale = (global.clientInformation || global.navigator || Object.create(null)).language ||
-           (global.navigator &&
-             (global.navigator.userLanguage ||
-             (global.navigator.languages && global.navigator.languages[0]) ||
-             (global.navigator.userAgent && global.navigator.userAgent.match(/;.(\w+\-\w+)/i)[1])))
+  locale = (global.navigator && (
+    (global.navigator.languages && global.navigator.languages[0]) ||
+    global.navigator.language ||
+    global.navigator.userLanguage
+  ))
+
+  if (!locale && global.navigator && global.navigator.userAgent) {
+    locale = global.navigator.userAgent.match(/;.(\w+\-\w+)/i)
+    
+    if (locale) return locale[1]
+  }
+
+  if (!locale) {
+    locale = (global.clientInformation || Object.create(null)).language
+  }
 
   if (!locale) {
     if (global.Intl && typeof global.Intl.DateTimeFormat === 'function') {

--- a/src/index.js
+++ b/src/index.js
@@ -3,10 +3,6 @@ var formatLocale = require('./utils').formatLocale
 function getLocale(locale) {
   if (locale) return locale
 
-  if (global.Intl && typeof global.Intl.DateTimeFormat === 'function') {
-    return global.Intl.DateTimeFormat().resolvedOptions && global.Intl.DateTimeFormat().resolvedOptions().locale
-  }
-
   if (global.chrome && global.chrome.app && typeof global.chrome.app.getDetails === 'function') {
     locale = global.chrome.app.getDetails()
 
@@ -21,11 +17,17 @@ function getLocale(locale) {
              (global.navigator.languages && global.navigator.languages[0]) ||
              (global.navigator.userAgent && global.navigator.userAgent.match(/;.(\w+\-\w+)/i)[1])))
 
-  if (!locale && ['LANG', 'LANGUAGE'].some(Object.hasOwnProperty, process.env)) {
-    return (process.env.LANG ||
-            process.env.LANGUAGE ||
-            String()).replace(/[.:].*/, '')
-                     .replace('_', '-')
+  if (!locale) {
+    if (global.Intl && typeof global.Intl.DateTimeFormat === 'function') {
+      locale = global.Intl.DateTimeFormat().resolvedOptions && global.Intl.DateTimeFormat().resolvedOptions().locale
+    }
+    
+    if (!locale && ['LANG', 'LANGUAGE'].some(Object.hasOwnProperty, process.env)) {
+      return (process.env.LANG ||
+              process.env.LANGUAGE ||
+              String()).replace(/[.:].*/, '')
+                       .replace('_', '-')
+    }
   }
 
   return locale

--- a/src/index.js
+++ b/src/index.js
@@ -6,7 +6,7 @@ function getLocale(locale) {
   if (global.chrome && global.chrome.app && typeof global.chrome.app.getDetails === 'function') {
     locale = global.chrome.app.getDetails()
 
-    if (locale) {
+    if (locale && locale.current_locale) {
       return locale.current_locale
     }
   }


### PR DESCRIPTION
- It seems like `global.chrome.app.getDetails()` has been deprecated since it now emits only `null`.
- Sometimes, `Intl.DateTimeFormat()` returns the wrong value so I've make it a fallback to the other methods.
- Updated the deps.
- Re-prioritize the order.